### PR TITLE
#20 Add `maps.Delete` helper

### DIFF
--- a/maps/writer.go
+++ b/maps/writer.go
@@ -17,3 +17,13 @@ func Delete[K comparable, V any](container map[K]V, keys ...K) {
 		delete(container, key)
 	}
 }
+
+// DeleteBy deletes keys from a map by a predicate.
+// If predicate returns true, key will be deleted.
+func DeleteBy[K comparable, V any](container map[K]V, predicate func(key K, value V) bool) {
+	for key, value := range container {
+		if predicate(key, value) {
+			delete(container, key)
+		}
+	}
+}

--- a/maps/writer.go
+++ b/maps/writer.go
@@ -9,3 +9,11 @@ func Set[K comparable, V any](container map[K]V, key K, value V) (old V, ok bool
 
 	return old, ok
 }
+
+// Delete deletes keys from a provided map.
+// This function is just a wrapper around `delete` function, but with a support of variadic keys.
+func Delete[K comparable, V any](container map[K]V, keys ...K) {
+	for _, key := range keys {
+		delete(container, key)
+	}
+}

--- a/maps/writer_example_test.go
+++ b/maps/writer_example_test.go
@@ -27,3 +27,30 @@ func ExampleSet() {
 	//  false
 	// string1 true
 }
+
+func ExampleDelete() {
+	container := map[string]int{
+		"test":  1,
+		"test2": 2,
+		"test3": 3,
+		"test5": 5,
+		"test6": 6,
+		"test7": 7,
+	}
+	fmt.Println(container)
+
+	maps.Delete(container, "test2", "test3", "test4")
+	fmt.Println(container)
+
+	maps.Delete(container, []string{"test5", "test6"}...)
+	fmt.Println(container)
+
+	maps.Delete(container)
+	fmt.Println(container)
+
+	// Output:
+	// map[test:1 test2:2 test3:3 test5:5 test6:6 test7:7]
+	// map[test:1 test5:5 test6:6 test7:7]
+	// map[test:1 test7:7]
+	// map[test:1 test7:7]
+}

--- a/maps/writer_example_test.go
+++ b/maps/writer_example_test.go
@@ -54,3 +54,26 @@ func ExampleDelete() {
 	// map[test:1 test7:7]
 	// map[test:1 test7:7]
 }
+
+func ExampleDeleteBy() {
+	container := map[string]int{
+		"test":          1,
+		"test2":         2,
+		"test3":         3,
+		"test5":         5,
+		"test6":         6,
+		"test7":         7,
+		"test_log_name": 3,
+	}
+	fmt.Println(container)
+
+	maps.DeleteBy(container, func(key string, value int) bool {
+		// Remove all even values and all keys with length more than 5.
+		return value%2 == 0 || len(key) > 5
+	})
+	fmt.Println(container)
+
+	// Output:
+	// map[test:1 test2:2 test3:3 test5:5 test6:6 test7:7 test_log_name:3]
+	// map[test:1 test3:3 test5:5 test7:7]
+}

--- a/maps/writer_test.go
+++ b/maps/writer_test.go
@@ -69,3 +69,32 @@ func TestDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteBy(t *testing.T) {
+	t.Parallel()
+
+	provider := []struct {
+		input     map[int]int
+		predicate func(key int, value int) bool
+		exp       map[int]int
+	}{
+		{nil, func(key int, value int) bool { return key == 5 }, nil},
+		{map[int]int{}, func(key int, value int) bool { return key == 5 }, map[int]int{}},
+		{map[int]int{1: 3, 5: 6, 8: 2}, func(key int, value int) bool { return key == 5 }, map[int]int{1: 3, 8: 2}},
+		{map[int]int{1: 3, 5: 6, 8: 2}, func(key int, value int) bool { return value == 6 }, map[int]int{1: 3, 8: 2}},
+	}
+
+	for idx, prov := range provider {
+		prov := prov
+
+		t.Run(fmt.Sprintf("TestDeleteBy_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			maps.DeleteBy(prov.input, prov.predicate)
+
+			if !reflect.DeepEqual(prov.input, prov.exp) {
+				t.Errorf("Unexpected map, expected: %v, got: %v", prov.exp, prov.input)
+			}
+		})
+	}
+}

--- a/maps/writer_test.go
+++ b/maps/writer_test.go
@@ -2,6 +2,7 @@ package maps_test
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/aohorodnyk/stl/maps"
@@ -36,6 +37,34 @@ func TestSet(t *testing.T) {
 
 			if old != prov.expValue {
 				t.Errorf("Unexpected value, expected: %d, got: %d", prov.expValue, old)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	provider := []struct {
+		input map[int]int
+		keys  []int
+		exp   map[int]int
+	}{
+		{nil, []int{5, 3}, nil},
+		{map[int]int{}, []int{5, 3}, map[int]int{}},
+		{map[int]int{1: 3, 5: 6, 8: 2}, []int{12, 8}, map[int]int{1: 3, 5: 6}},
+	}
+
+	for idx, prov := range provider {
+		prov := prov
+
+		t.Run(fmt.Sprintf("TestDelete_%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			maps.Delete(prov.input, prov.keys...)
+
+			if reflect.DeepEqual(prov.input, prov.exp) == false {
+				t.Errorf("Unexpected map, expected: %v, got: %v", prov.exp, prov.input)
 			}
 		})
 	}


### PR DESCRIPTION
`maps.Delete` supports variadic slice of keys.
It works well with 0 parameters and with multiple parameters at the same time.

Close #20 